### PR TITLE
Fix body background path and overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ body {
   margin: 0;
   padding: 0;
   color: white;
-  background-image: url('background.jpg');
+  background-image: linear-gradient(rgba(255,165,0,0.35), rgba(255,229,204,0.35)), url('background.jpg.jpeg');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
@@ -121,6 +121,5 @@ button:hover {
 .talk-animation {
   transform: rotateY(180deg);
 }
-background-image: url('https://images.unsplash.com/photo-1506748686214-e9df14d4d9d0?auto=format&fit=crop&w=1400&q=80');
 
 


### PR DESCRIPTION
## Summary
- correct background image path in `style.css`
- remove leftover Unsplash image lines
- apply gradient overlay to the body background

## Testing
- `w3m -dump -cols 80 index.html | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6854b30dbf888322a72046ff55b43a64