### PR TITLE
Show RT/SQ score and new layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -2,18 +2,21 @@ let profiles = [
   {
     name: "Jess",
     age: 29,
+    rtSq: 72,
     prompt: "Two truths and a lie: I ran a marathon, I met Drake, I hate pizza.",
     photo: "https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?auto=format&fit=crop&w=600&q=80"
   },
   {
     name: "Aiden",
     age: 32,
+    rtSq: 65,
     prompt: "Ask me about my dog and you'll win my heart.",
     photo: "https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=600&q=80"
   },
   {
     name: "Maya",
     age: 26,
+    rtSq: 81,
     prompt: "I’ve been skydiving twice and survived both.",
     photo: "https://images.unsplash.com/photo-1502685104226-ee32379fefbe?auto=format&fit=crop&w=600&q=80"
   }
@@ -32,8 +35,11 @@ function showProfile() {
 
   card.innerHTML = `
     <img class="profile-pic" src="${profile.photo}" alt="${profile.name}" />
-    <h2>${profile.name}, ${profile.age}</h2>
-    <p>${profile.prompt}</p>
+    <div class="profile-text">
+      <h2>${profile.name}, ${profile.age}</h2>
+      <p class="score">RT/SQ Score: ${profile.rtSq}</p>
+      <p>${profile.prompt}</p>
+    </div>
   `;
 }
 

--- a/style.css
+++ b/style.css
@@ -38,13 +38,26 @@ h1 {
   transition: transform 0.6s;
   border-radius: 25px;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  gap: 20px;
 }
 
 .profile-pic {
-  width: 100%;
+  width: 50%;
   border-radius: 20px;
-  margin-bottom: 15px;
+  margin-bottom: 0;
   border: 2px solid white;
+}
+
+.profile-text {
+  flex: 1;
+  text-align: left;
+}
+
+.score {
+  font-weight: 600;
+  margin-top: 5px;
 }
 
 #profile-card h2 {
@@ -53,7 +66,7 @@ h1 {
 }
 
 #profile-card p {
-  font-size: 1em;
+  font-size: 1.2em;
   opacity: 0.9;
   margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- add RT/SQ score to sample profiles
- show the score on profile cards
- make profile cards flex rows and shrink the image
- enlarge text size for profile details

## Testing
- `python3 -m http.server 8000` then `curl http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6854c4105bd883229b1d884ba1978a05